### PR TITLE
Add Hamming problem for Standard ML track 

### DIFF
--- a/binary/example.sml
+++ b/binary/example.sml
@@ -1,0 +1,27 @@
+exception NonBinaryDigitFound
+exception EmptyBinaryStringFound
+
+(* accepts a binary string and converts it to the decimal equivalant *)
+fun binaryToDecimal n = let
+    val digits = List.map (fn c => (ord c) - 48) (explode n)
+    val len = List.length digits
+    fun validateBinaryDigits []      = true
+      | validateBinaryDigits (d::ds) = if d <> 0 andalso d <> 1 then false
+                                       else validateBinaryDigits ds
+    fun even n = (n mod 2) = 0
+    fun expt a b = let
+        fun loop x 0 acc = acc
+          | loop x 1 acc = x * acc
+          | loop x n acc = if (even n) then loop (x * x) (n div 2) acc
+                           else             loop (x * x) ((n - 1) div 2) (x * acc)
+    in
+        loop a b 1
+    end
+    fun f' []      mult acc = acc 
+      | f' (x::xs) mult acc = f' xs (mult - 1) (acc + (x * (expt 2 mult)))
+in
+    if len = 0 then raise EmptyBinaryStringFound
+    else if (validateBinaryDigits digits) then f' digits (len - 1) 0
+    else raise NonBinaryDigitFound
+end
+

--- a/binary/test_binary.sml
+++ b/binary/test_binary.sml
@@ -1,0 +1,32 @@
+use "example.sml";
+
+val test_cases = [
+    ("0",          0),
+    ("01",         1),
+    ("10",         2),
+    ("11",         3),
+    ("100",        4),
+    ("1111",      15),
+    ("10000000", 128)
+];
+
+val error_test_cases = [
+    ("",     EmptyBinaryStringFound),
+    ("200",  NonBinaryDigitFound),
+    ("a62b", NonBinaryDigitFound)
+];
+
+fun run_tests [] = []
+  | run_tests ((bin_string,expected)::ts) =
+       (binaryToDecimal bin_string = expected) :: run_tests ts
+
+fun run_error_tests [] = []
+  | run_error_tests ((bin_string,expected: exn)::ts) =
+       (binaryToDecimal bin_string handle expected => 1) :: run_error_tests ts
+
+val allNormalTestsPass =
+    List.foldl (fn (x,y) => x andalso y) true (run_tests test_cases)
+val allErrorTestsPass =
+    (List.foldl (fn (x,y) => x + y) 0 (run_error_tests error_test_cases)) = length error_test_cases
+val allTestsPass = allNormalTestsPass andalso allErrorTestsPass
+    

--- a/config.json
+++ b/config.json
@@ -7,7 +7,8 @@
   "problems": [
     "accumulate",
     "allergies",
-    "anagram"
+    "anagram",
+    "binary"
   ],
   "deprecated": [
 

--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
     "accumulate",
     "allergies",
     "anagram",
-    "binary"
+    "binary",
+    "hamming"  
   ],
   "deprecated": [
 

--- a/hamming/example.sml
+++ b/hamming/example.sml
@@ -1,0 +1,10 @@
+exception NonEqualLengthStringsFound;
+fun hamming (s1, s2) = let
+    val chars1 = explode s1
+    val chars2 = explode s2
+    fun hamming' ([],[]) acc = acc
+      | hamming' ((x::xs),(y::ys)) acc = hamming' (xs, ys) (acc + (if x = y then 0 else 1))
+in
+    if (length chars1) <> (length chars2) then raise NonEqualLengthStringsFound
+    else hamming' (chars1, chars2) 0
+end

--- a/hamming/test_hamming.sml
+++ b/hamming/test_hamming.sml
@@ -1,0 +1,28 @@
+use "example.sml";
+
+val test_cases = [
+    (("GAGCCTACTAACGGGAT","CATCGTAATGACGGCCT"),7),
+    (("CAT","DOG"), 3),
+    (("DEPOSIT","DOPIEST"),4)
+];
+
+val error_test_cases = [
+    (("",       "A"), NonEqualLengthStringsFound),
+    (("A",       ""), NonEqualLengthStringsFound),
+    (("ABCD", "ABC"), NonEqualLengthStringsFound)
+];
+
+fun run_tests [] = []
+  | run_tests (((s1,s2),expected)::ts) =
+       (hamming (s1,s2) = expected) :: run_tests ts
+
+fun run_error_tests [] = []
+  | run_error_tests (((s1,s2),expected)::ts) =
+       (hamming (s1,s2) handle expected => 1) :: run_error_tests ts
+
+val allNormalTestsPass =
+    List.foldl (fn (x,y) => x andalso y) true (run_tests test_cases)
+val allErrorTestsPass =
+    (List.foldl (fn (x,y) => x + y) 0 (run_error_tests error_test_cases)) = length error_test_cases
+val allTestsPass = allNormalTestsPass andalso allErrorTestsPass
+    


### PR DESCRIPTION
There is now an example program example.sml and test program test_hamming.sml for the hamming problem. When testing this code a warning for "nonexhaustive match" may appear, it can be ignored for this exercise. It is just the SML checker trying to say that the function not handle strings that are not the same length, but that is already an invariant for this problem.