### PR TITLE
Add hamming problem to Standard ML track

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
     "accumulate",
     "allergies",
     "anagram",
-    "binary"
+    "binary",
+    "hamming"
   ],
   "deprecated": [
 

--- a/hamming/example.sml
+++ b/hamming/example.sml
@@ -1,0 +1,10 @@
+exception NonEqualLengthStringsFound;
+fun hamming (s1, s2) = let
+    val chars1 = explode s1
+    val chars2 = explode s2
+    fun hamming' ([],[]) acc = acc
+      | hamming' ((x::xs),(y::ys)) acc = hamming' (xs, ys) (acc + (if x = y then 0 else 1))
+in
+    if (length chars1) <> (length chars2) then raise NonEqualLengthStringsFound
+    else hamming' (chars1, chars2) 0
+end

--- a/hamming/test_hamming.sml
+++ b/hamming/test_hamming.sml
@@ -1,0 +1,28 @@
+use "example.sml";
+
+val test_cases = [
+    (("GAGCCTACTAACGGGAT","CATCGTAATGACGGCCT"),7),
+    (("CAT","DOG"), 3),
+    (("DEPOSIT","DOPIEST"),4)
+];
+
+val error_test_cases = [
+    (("",       "A"), NonEqualLengthStringsFound),
+    (("A",       ""), NonEqualLengthStringsFound),
+    (("ABCD", "ABC"), NonEqualLengthStringsFound)
+];
+
+fun run_tests [] = []
+  | run_tests (((s1,s2),expected)::ts) =
+       (hamming (s1,s2) = expected) :: run_tests ts
+
+fun run_error_tests [] = []
+  | run_error_tests (((s1,s2),expected)::ts) =
+       (hamming (s1,s2) handle expected => 1) :: run_error_tests ts
+
+val allNormalTestsPass =
+    List.foldl (fn (x,y) => x andalso y) true (run_tests test_cases)
+val allErrorTestsPass =
+    (List.foldl (fn (x,y) => x + y) 0 (run_error_tests error_test_cases)) = length error_test_cases
+val allTestsPass = allNormalTestsPass andalso allErrorTestsPass
+    


### PR DESCRIPTION
There is now an example program example.sml and test program test_hamming.sml for the hamming problem. When testing this code a warning for "nonexhaustive match" may appear, it can be ignored for this exercise. It is just the SML checker trying to say that the function not handle strings that are not the same length, but that is already an invariant for this problem.